### PR TITLE
Fix mako template

### DIFF
--- a/edx-platform/zollege/lms/templates/head-extra.html
+++ b/edx-platform/zollege/lms/templates/head-extra.html
@@ -1,3 +1,4 @@
+## mako
 <%
 from openedx.core.djangolib.js_utils import  js_escaped_string
 %>


### PR DESCRIPTION
The /logout page is escaping the contents of this file, this fixes that problem.

## Reviewer:
- [ ] @amalbas 